### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/src/EntityFrameworkCore.Testing.Moq.PackageVerification.Tests/EntityFrameworkCore.Testing.Moq.PackageVerification.Tests.csproj
+++ b/src/EntityFrameworkCore.Testing.Moq.PackageVerification.Tests/EntityFrameworkCore.Testing.Moq.PackageVerification.Tests.csproj
@@ -24,17 +24,17 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="EntityFrameworkCore.Testing.Moq" Version="3.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Hi@rgvlee, I found an issue in the EntityFrameworkCore.Testing.Moq.PackageVerification.Tests.csproj:

Packages Microsoft.EntityFrameworkCore.InMemory v5.0.6, Microsoft.EntityFrameworkCore.Sqlite v5.0.6, Microsoft.EntityFrameworkCore.SqlServerand v5.0.6, NUnit3TestAdapter v3.17.0 and  Microsoft.NET.Test.Sdk v16.9.4 transitively introduce 124 dependencies into EntityFrameworkCore.Testing’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/EntityFrameworkCore-Testing.html)), while Microsoft.EntityFrameworkCore.InMemory v5.0.8, Microsoft.EntityFrameworkCore.Sqlite v5.0.8, Microsoft.EntityFrameworkCore.SqlServerand v5.0.8, NUnit3TestAdapter v4.0.0 and  Microsoft.NET.Test.Sdk v16.10.0 can only introduce 90 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/EntityFrameworkCore-Testing_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose