### PR TITLE
Remove dependency to Microsoft.EntityFrameworkCore.SqlServer

### DIFF
--- a/EntityFrameworkCore.Testing.Moq.nuspec
+++ b/EntityFrameworkCore.Testing.Moq.nuspec
@@ -22,7 +22,7 @@ EntityFrameworkCore.Testing v8.x = EntityFrameworkCore 8</description>
     <dependencies>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.EntityFrameworkCore.InMemory" version="[8,9)" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.EntityFrameworkCore.SqlServer" version="[8,9)" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.EntityFrameworkCore.Relational" version="[8,9)" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging" version="[8,9)" exclude="Build,Analyzers" />
         <dependency id="Moq" version="4.9.0" exclude="Build,Analyzers" />
         <dependency id="rgvlee.Core" version="1.2.1" exclude="Build,Analyzers" />

--- a/EntityFrameworkCore.Testing.NSubstitute.nuspec
+++ b/EntityFrameworkCore.Testing.NSubstitute.nuspec
@@ -22,7 +22,7 @@ EntityFrameworkCore.Testing v8.x = EntityFrameworkCore 8</description>
     <dependencies>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.EntityFrameworkCore.InMemory" version="[8,9)" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.EntityFrameworkCore.SqlServer" version="[8,9)" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.EntityFrameworkCore.Relational" version="[8,9)" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging" version="[8,9)" exclude="Build,Analyzers" />
         <dependency id="NSubstitute" version="4.1.0" exclude="Build,Analyzers" />
         <dependency id="rgvlee.Core" version="1.2.1" exclude="Build,Analyzers" />

--- a/src/EntityFrameworkCore.Testing.Common.Tests/EntityFrameworkCore.Testing.Common.Tests.csproj
+++ b/src/EntityFrameworkCore.Testing.Common.Tests/EntityFrameworkCore.Testing.Common.Tests.csproj
@@ -31,7 +31,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkCore.Testing.Common/EntityFrameworkCore.Testing.Common.csproj
+++ b/src/EntityFrameworkCore.Testing.Common/EntityFrameworkCore.Testing.Common.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="rgvlee.Core" Version="1.2.1" />
   </ItemGroup>


### PR DESCRIPTION
Links to issue #146.

(Also updated System.Data.SqlClient to version 4.8.6 in tests - previous version has at least one vulnerability with high severity)