### PR TITLE
Added support for .NET 9

### DIFF
--- a/.github/workflows/continuous-integration-checks.yml
+++ b/.github/workflows/continuous-integration-checks.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Build
         run: dotnet build --configuration Release
@@ -30,12 +30,12 @@ jobs:
 
       - name: Update dependencies
         run: |
-          dotnet add src/EntityFrameworkCore.Testing.Common package Microsoft.EntityFrameworkCore.InMemory --version 8.*
-          dotnet add src/EntityFrameworkCore.Testing.Common package Microsoft.EntityFrameworkCore.SqlServer --version 8.*
-          dotnet add src/EntityFrameworkCore.Testing.Common package Microsoft.Extensions.Logging --version 8.*
+          dotnet add src/EntityFrameworkCore.Testing.Common package Microsoft.EntityFrameworkCore.InMemory --version 9.*
+          dotnet add src/EntityFrameworkCore.Testing.Common package Microsoft.EntityFrameworkCore.SqlServer --version 9.*
+          dotnet add src/EntityFrameworkCore.Testing.Common package Microsoft.Extensions.Logging --version 9.*
           dotnet add src/EntityFrameworkCore.Testing.Common package rgvlee.Core
 
-          dotnet add src/EntityFrameworkCore.Testing.Common.Tests package Microsoft.Extensions.Logging.Console --version 8.*
+          dotnet add src/EntityFrameworkCore.Testing.Common.Tests package Microsoft.Extensions.Logging.Console --version 9.*
 
           dotnet add src/EntityFrameworkCore.Testing.Moq package Moq
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Setup NuGet
         uses: nuget/setup-nuget@v1

--- a/EntityFrameworkCore.Testing.Moq.nuspec
+++ b/EntityFrameworkCore.Testing.Moq.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>EntityFrameworkCore.Testing.Moq</id>
-    <version>8.0.0</version>
+    <version>9.0.0</version>
     <authors>rgvlee</authors>
     <owners>rgvlee</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -15,27 +15,28 @@ EntityFrameworkCore.Testing v2.x = EntityFrameworkCore 3
 EntityFrameworkCore.Testing v3.x = EntityFrameworkCore 5
 EntityFrameworkCore.Testing v4.x = EntityFrameworkCore 6
 EntityFrameworkCore.Testing v5.x = EntityFrameworkCore 7
-EntityFrameworkCore.Testing v8.x = EntityFrameworkCore 8</description>
+EntityFrameworkCore.Testing v8.x = EntityFrameworkCore 8
+EntityFrameworkCore.Testing v9.x = EntityFrameworkCore 9</description>
     <copyright>Copyright (c) 2022 Lee Anderson</copyright>
     <tags>EntityFrameworkCore EFCore Moq mock testing</tags>
     <repository url="https://github.com/rgvlee/EntityFrameworkCore.Testing" />
     <dependencies>
-      <group targetFramework="net8.0">
-        <dependency id="Microsoft.EntityFrameworkCore.InMemory" version="[8,9)" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.EntityFrameworkCore.SqlServer" version="[8,9)" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Extensions.Logging" version="[8,9)" exclude="Build,Analyzers" />
+      <group targetFramework="net9.0">
+        <dependency id="Microsoft.EntityFrameworkCore.InMemory" version="[9,10)" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.EntityFrameworkCore.SqlServer" version="[9,10)" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.Logging" version="[9,10)" exclude="Build,Analyzers" />
         <dependency id="Moq" version="4.9.0" exclude="Build,Analyzers" />
         <dependency id="rgvlee.Core" version="1.2.1" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="src\EntityFrameworkCore.Testing.Common\bin\Release\net8.0\EntityFrameworkCore.Testing.Common.dll" target="lib\net8.0" />
-    <file src="src\EntityFrameworkCore.Testing.Common\bin\Release\net8.0\EntityFrameworkCore.Testing.Common.xml" target="lib\net8.0" />
-    <file src="src\EntityFrameworkCore.Testing.Common\bin\Release\net8.0\EntityFrameworkCore.Testing.Common.pdb" target="lib\net8.0" />
-    <file src="src\EntityFrameworkCore.Testing.Moq\bin\Release\net8.0\EntityFrameworkCore.Testing.Moq.dll" target="lib\net8.0" />
-    <file src="src\EntityFrameworkCore.Testing.Moq\bin\Release\net8.0\EntityFrameworkCore.Testing.Moq.xml" target="lib\net8.0" />
-    <file src="src\EntityFrameworkCore.Testing.Moq\bin\Release\net8.0\EntityFrameworkCore.Testing.Moq.pdb" target="lib\net8.0" />
+    <file src="src\EntityFrameworkCore.Testing.Common\bin\Release\net9.0\EntityFrameworkCore.Testing.Common.dll" target="lib\net9.0" />
+    <file src="src\EntityFrameworkCore.Testing.Common\bin\Release\net9.0\EntityFrameworkCore.Testing.Common.xml" target="lib\net9.0" />
+    <file src="src\EntityFrameworkCore.Testing.Common\bin\Release\net9.0\EntityFrameworkCore.Testing.Common.pdb" target="lib\net9.0" />
+    <file src="src\EntityFrameworkCore.Testing.Moq\bin\Release\net9.0\EntityFrameworkCore.Testing.Moq.dll" target="lib\net9.0" />
+    <file src="src\EntityFrameworkCore.Testing.Moq\bin\Release\net9.0\EntityFrameworkCore.Testing.Moq.xml" target="lib\net9.0" />
+    <file src="src\EntityFrameworkCore.Testing.Moq\bin\Release\net9.0\EntityFrameworkCore.Testing.Moq.pdb" target="lib\net9.0" />
     <file src="LICENSE" />
   </files>
 </package>

--- a/EntityFrameworkCore.Testing.NSubstitute.nuspec
+++ b/EntityFrameworkCore.Testing.NSubstitute.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>EntityFrameworkCore.Testing.NSubstitute</id>
-    <version>8.0.0</version>
+    <version>9.0.0</version>
     <authors>rgvlee</authors>
     <owners>rgvlee</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -15,27 +15,28 @@ EntityFrameworkCore.Testing v2.x = EntityFrameworkCore 3
 EntityFrameworkCore.Testing v3.x = EntityFrameworkCore 5
 EntityFrameworkCore.Testing v4.x = EntityFrameworkCore 6
 EntityFrameworkCore.Testing v5.x = EntityFrameworkCore 7
-EntityFrameworkCore.Testing v8.x = EntityFrameworkCore 8</description>
+EntityFrameworkCore.Testing v8.x = EntityFrameworkCore 8
+EntityFrameworkCore.Testing v9.x = EntityFrameworkCore 9</description>
     <copyright>Copyright (c) 2022 Lee Anderson</copyright>
     <tags>EntityFrameworkCore EFCore NSubstitute nsub mock testing</tags>
     <repository url="https://github.com/rgvlee/EntityFrameworkCore.Testing" />
     <dependencies>
-      <group targetFramework="net8.0">
-        <dependency id="Microsoft.EntityFrameworkCore.InMemory" version="[8,9)" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.EntityFrameworkCore.SqlServer" version="[8,9)" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Extensions.Logging" version="[8,9)" exclude="Build,Analyzers" />
+      <group targetFramework="net9.0">
+        <dependency id="Microsoft.EntityFrameworkCore.InMemory" version="[9,10)" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.EntityFrameworkCore.SqlServer" version="[9,10)" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.Logging" version="[9,10)" exclude="Build,Analyzers" />
         <dependency id="NSubstitute" version="4.1.0" exclude="Build,Analyzers" />
         <dependency id="rgvlee.Core" version="1.2.1" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="src\EntityFrameworkCore.Testing.Common\bin\Release\net8.0\EntityFrameworkCore.Testing.Common.dll" target="lib\net8.0" />
-    <file src="src\EntityFrameworkCore.Testing.Common\bin\Release\net8.0\EntityFrameworkCore.Testing.Common.xml" target="lib\net8.0" />
-    <file src="src\EntityFrameworkCore.Testing.Common\bin\Release\net8.0\EntityFrameworkCore.Testing.Common.pdb" target="lib\net8.0" />
-    <file src="src\EntityFrameworkCore.Testing.NSubstitute\bin\Release\net8.0\EntityFrameworkCore.Testing.NSubstitute.dll" target="lib\net8.0" />
-    <file src="src\EntityFrameworkCore.Testing.NSubstitute\bin\Release\net8.0\EntityFrameworkCore.Testing.NSubstitute.xml" target="lib\net8.0" />
-    <file src="src\EntityFrameworkCore.Testing.NSubstitute\bin\Release\net8.0\EntityFrameworkCore.Testing.NSubstitute.pdb" target="lib\net8.0" />
+    <file src="src\EntityFrameworkCore.Testing.Common\bin\Release\net9.0\EntityFrameworkCore.Testing.Common.dll" target="lib\net9.0" />
+    <file src="src\EntityFrameworkCore.Testing.Common\bin\Release\net9.0\EntityFrameworkCore.Testing.Common.xml" target="lib\net9.0" />
+    <file src="src\EntityFrameworkCore.Testing.Common\bin\Release\net9.0\EntityFrameworkCore.Testing.Common.pdb" target="lib\net9.0" />
+    <file src="src\EntityFrameworkCore.Testing.NSubstitute\bin\Release\net9.0\EntityFrameworkCore.Testing.NSubstitute.dll" target="lib\net9.0" />
+    <file src="src\EntityFrameworkCore.Testing.NSubstitute\bin\Release\net9.0\EntityFrameworkCore.Testing.NSubstitute.xml" target="lib\net9.0" />
+    <file src="src\EntityFrameworkCore.Testing.NSubstitute\bin\Release\net9.0\EntityFrameworkCore.Testing.NSubstitute.pdb" target="lib\net9.0" />
     <file src="LICENSE" />
   </files>
 </package>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EntityFrameworkCore.Testing
 
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/6d641ce391264f45b99acee8694a88d6?branch=8.x)](https://www.codacy.com/manual/rgvlee/EntityFrameworkCore.Testing?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=rgvlee/EntityFrameworkCore.Testing&amp;utm_campaign=Badge_Grade) [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/6d641ce391264f45b99acee8694a88d6?branch=8.x)](https://www.codacy.com/manual/rgvlee/EntityFrameworkCore.Testing?utm_source=github.com&utm_medium=referral&utm_content=rgvlee/EntityFrameworkCore.Testing&utm_campaign=Badge_Coverage)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/6d641ce391264f45b99acee8694a88d6?branch=9.x)](https://www.codacy.com/manual/rgvlee/EntityFrameworkCore.Testing?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=rgvlee/EntityFrameworkCore.Testing&amp;utm_campaign=Badge_Grade) [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/6d641ce391264f45b99acee8694a88d6?branch=9.x)](https://www.codacy.com/manual/rgvlee/EntityFrameworkCore.Testing?utm_source=github.com&utm_medium=referral&utm_content=rgvlee/EntityFrameworkCore.Testing&utm_campaign=Badge_Coverage)
 
 ## Overview
 
@@ -9,6 +9,12 @@ EntityFrameworkCore.Testing adds relational support to the Microsoft EntityFrame
 The aim of this library is to allow you use the in-memory database provider in unit tests where the SUT invokes a relational operation. It'll allow you to specify expected results for these relational operations. It does not test your relational operations.
 
 [Microsoft does not recommend mocking a db context](https://docs.microsoft.com/en-us/ef/core/testing/#unit-testing) and EntityFrameworkCore.Testing follows this advice by sending operations supported by the in-memory database provider to the in-memory database provider.
+
+### EntityFrameworkCore 9
+
+- [Source](https://github.com/rgvlee/EntityFrameworkCore.Testing/tree/9.x)
+- [EntityFrameworkCore.Testing.Moq - NuGet](https://www.nuget.org/packages/EntityFrameworkCore.Testing.Moq/9.0.0)
+- [EntityFrameworkCore.Testing.NSubstitute - NuGet](https://www.nuget.org/packages/EntityFrameworkCore.Testing.NSubstitute/9.0.0)
 
 ### EntityFrameworkCore 8
 

--- a/src/EntityFrameworkCore.DefaultBehaviour.Tests/EntityFrameworkCore.DefaultBehaviour.Tests.csproj
+++ b/src/EntityFrameworkCore.DefaultBehaviour.Tests/EntityFrameworkCore.DefaultBehaviour.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/EntityFrameworkCore.Testing.Common.Tests/EntityFrameworkCore.Testing.Common.Tests.csproj
+++ b/src/EntityFrameworkCore.Testing.Common.Tests/EntityFrameworkCore.Testing.Common.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/EntityFrameworkCore.Testing.Common/EntityFrameworkCore.Testing.Common.csproj
+++ b/src/EntityFrameworkCore.Testing.Common/EntityFrameworkCore.Testing.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Authors>rgvlee</Authors>
     <LangVersion>10</LangVersion>
   </PropertyGroup>
@@ -18,9 +18,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="rgvlee.Core" Version="1.2.1" />
   </ItemGroup>
 

--- a/src/EntityFrameworkCore.Testing.Moq.Tests/EntityFrameworkCore.Testing.Moq.Tests.csproj
+++ b/src/EntityFrameworkCore.Testing.Moq.Tests/EntityFrameworkCore.Testing.Moq.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/EntityFrameworkCore.Testing.Moq/EntityFrameworkCore.Testing.Moq.csproj
+++ b/src/EntityFrameworkCore.Testing.Moq/EntityFrameworkCore.Testing.Moq.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Authors>rgvlee</Authors>
     <LangVersion>10</LangVersion>
   </PropertyGroup>

--- a/src/EntityFrameworkCore.Testing.Moq/Extensions/DbContextExtensions.cs
+++ b/src/EntityFrameworkCore.Testing.Moq/Extensions/DbContextExtensions.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using EntityFrameworkCore.Testing.Common.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -139,10 +140,12 @@ namespace EntityFrameworkCore.Testing.Moq.Extensions
                 .RawSqlCommandBuilder;
 
             Mock.Get(existingRawSqlCommandBuilder)
-                .Setup(m => m.Build(It.Is<string>(s => s.Contains(sql, StringComparison.OrdinalIgnoreCase)),
-                    It.Is<IEnumerable<object>>(p => ParameterMatchingHelper.DoInvocationParametersMatchSetUpParameters(parameters, p))))
-                .Returns((string providedSql, IEnumerable<object> providedParameters) => rawSqlCommand)
-                .Callback((string providedSql, IEnumerable<object> providedParameters) =>
+                .Setup(m => m.Build(
+                    It.Is<string>(s => s.Contains(sql, StringComparison.OrdinalIgnoreCase)),
+                    It.Is<IEnumerable<object>>(p => ParameterMatchingHelper.DoInvocationParametersMatchSetUpParameters(parameters, p)),
+                    It.IsAny<IModel>()))
+                .Returns((string providedSql, IEnumerable<object> providedParameters, IModel model) => rawSqlCommand)
+                .Callback((string providedSql, IEnumerable<object> providedParameters, IModel model) =>
                 {
                     callback?.Invoke(providedSql, providedParameters);
 

--- a/src/EntityFrameworkCore.Testing.Moq/Extensions/DbContextExtensions.cs
+++ b/src/EntityFrameworkCore.Testing.Moq/Extensions/DbContextExtensions.cs
@@ -144,8 +144,8 @@ namespace EntityFrameworkCore.Testing.Moq.Extensions
                     It.Is<string>(s => s.Contains(sql, StringComparison.OrdinalIgnoreCase)),
                     It.Is<IEnumerable<object>>(p => ParameterMatchingHelper.DoInvocationParametersMatchSetUpParameters(parameters, p)),
                     It.IsAny<IModel>()))
-                .Returns((string providedSql, IEnumerable<object> providedParameters, IModel model) => rawSqlCommand)
-                .Callback((string providedSql, IEnumerable<object> providedParameters, IModel model) =>
+                .Returns((string providedSql, IEnumerable<object> providedParameters, IModel _) => rawSqlCommand)
+                .Callback((string providedSql, IEnumerable<object> providedParameters, IModel _) =>
                 {
                     callback?.Invoke(providedSql, providedParameters);
 

--- a/src/EntityFrameworkCore.Testing.Moq/Extensions/DbContextExtensions.cs
+++ b/src/EntityFrameworkCore.Testing.Moq/Extensions/DbContextExtensions.cs
@@ -144,7 +144,7 @@ namespace EntityFrameworkCore.Testing.Moq.Extensions
                     It.Is<string>(s => s.Contains(sql, StringComparison.OrdinalIgnoreCase)),
                     It.Is<IEnumerable<object>>(p => ParameterMatchingHelper.DoInvocationParametersMatchSetUpParameters(parameters, p)),
                     It.IsAny<IModel>()))
-                .Returns((string providedSql, IEnumerable<object> providedParameters, IModel _) => rawSqlCommand)
+                .Returns((string _, IEnumerable<object> _, IModel _) => rawSqlCommand)
                 .Callback((string providedSql, IEnumerable<object> providedParameters, IModel _) =>
                 {
                     callback?.Invoke(providedSql, providedParameters);

--- a/src/EntityFrameworkCore.Testing.Moq/Helpers/MockedDbContextFactory.Internal.cs
+++ b/src/EntityFrameworkCore.Testing.Moq/Helpers/MockedDbContextFactory.Internal.cs
@@ -103,7 +103,7 @@ namespace EntityFrameworkCore.Testing.Moq.Helpers
             //Relational set up
             var rawSqlCommandBuilderMock = new Mock<IRawSqlCommandBuilder>();
             rawSqlCommandBuilderMock.Setup(m => m.Build(It.IsAny<string>(), It.IsAny<IEnumerable<object>>(), It.IsAny<IModel>()))
-                .Callback((string providedSql, IEnumerable<object> providedParameters, IModel model) => Logger.LogDebug("Catch all exception invoked"))
+                .Callback((string providedSql, IEnumerable<object> providedParameters, IModel _) => Logger.LogDebug("Catch all exception invoked"))
                 .Throws<InvalidOperationException>();
             var rawSqlCommandBuilder = rawSqlCommandBuilderMock.Object;
 
@@ -126,7 +126,7 @@ namespace EntityFrameworkCore.Testing.Moq.Helpers
 
             var serviceProviderMock = new Mock<IServiceProvider>();
             serviceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(IDatabaseFacadeDependencies)))).Returns((Type providedType) => dependencies);
-            serviceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(IModel)))).Returns((Type providedType) => new Mock<IModel>().Object);
+            serviceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(IModel)))).Returns((Type _) => new Mock<IModel>().Object);
             var serviceProvider = serviceProviderMock.Object;
 
             dbContextMock.As<IInfrastructure<IServiceProvider>>().Setup(m => m.Instance).Returns(() => serviceProvider);

--- a/src/EntityFrameworkCore.Testing.Moq/Helpers/MockedDbContextFactory.Internal.cs
+++ b/src/EntityFrameworkCore.Testing.Moq/Helpers/MockedDbContextFactory.Internal.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -101,8 +102,8 @@ namespace EntityFrameworkCore.Testing.Moq.Helpers
 
             //Relational set up
             var rawSqlCommandBuilderMock = new Mock<IRawSqlCommandBuilder>();
-            rawSqlCommandBuilderMock.Setup(m => m.Build(It.IsAny<string>(), It.IsAny<IEnumerable<object>>()))
-                .Callback((string providedSql, IEnumerable<object> providedParameters) => Logger.LogDebug("Catch all exception invoked"))
+            rawSqlCommandBuilderMock.Setup(m => m.Build(It.IsAny<string>(), It.IsAny<IEnumerable<object>>(), It.IsAny<IModel>()))
+                .Callback((string providedSql, IEnumerable<object> providedParameters, IModel model) => Logger.LogDebug("Catch all exception invoked"))
                 .Throws<InvalidOperationException>();
             var rawSqlCommandBuilder = rawSqlCommandBuilderMock.Object;
 
@@ -125,6 +126,7 @@ namespace EntityFrameworkCore.Testing.Moq.Helpers
 
             var serviceProviderMock = new Mock<IServiceProvider>();
             serviceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(IDatabaseFacadeDependencies)))).Returns((Type providedType) => dependencies);
+            serviceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(IModel)))).Returns((Type providedType) => new Mock<IModel>().Object);
             var serviceProvider = serviceProviderMock.Object;
 
             dbContextMock.As<IInfrastructure<IServiceProvider>>().Setup(m => m.Instance).Returns(() => serviceProvider);

--- a/src/EntityFrameworkCore.Testing.Moq/Helpers/MockedDbContextFactory.Internal.cs
+++ b/src/EntityFrameworkCore.Testing.Moq/Helpers/MockedDbContextFactory.Internal.cs
@@ -103,7 +103,7 @@ namespace EntityFrameworkCore.Testing.Moq.Helpers
             //Relational set up
             var rawSqlCommandBuilderMock = new Mock<IRawSqlCommandBuilder>();
             rawSqlCommandBuilderMock.Setup(m => m.Build(It.IsAny<string>(), It.IsAny<IEnumerable<object>>(), It.IsAny<IModel>()))
-                .Callback((string providedSql, IEnumerable<object> providedParameters, IModel _) => Logger.LogDebug("Catch all exception invoked"))
+                .Callback((string _, IEnumerable<object> _, IModel _) => Logger.LogDebug("Catch all exception invoked"))
                 .Throws<InvalidOperationException>();
             var rawSqlCommandBuilder = rawSqlCommandBuilderMock.Object;
 

--- a/src/EntityFrameworkCore.Testing.NSubstitute.Tests/EntityFrameworkCore.Testing.NSubstitute.Tests.csproj
+++ b/src/EntityFrameworkCore.Testing.NSubstitute.Tests/EntityFrameworkCore.Testing.NSubstitute.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/EntityFrameworkCore.Testing.NSubstitute/EntityFrameworkCore.Testing.NSubstitute.csproj
+++ b/src/EntityFrameworkCore.Testing.NSubstitute/EntityFrameworkCore.Testing.NSubstitute.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Authors>rgvlee</Authors>
     <LangVersion>10</LangVersion>
   </PropertyGroup>

--- a/src/EntityFrameworkCore.Testing.NSubstitute/Extensions/DbContextExtensions.cs
+++ b/src/EntityFrameworkCore.Testing.NSubstitute/Extensions/DbContextExtensions.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using EntityFrameworkCore.Testing.Common.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -136,7 +137,8 @@ namespace EntityFrameworkCore.Testing.NSubstitute.Extensions
 
             existingRawSqlCommandBuilder.Build(
                     Arg.Is<string>(s => s.Contains(sql, StringComparison.OrdinalIgnoreCase)),
-                    Arg.Is<IEnumerable<object>>(p => ParameterMatchingHelper.DoInvocationParametersMatchSetUpParameters(parameters, p)))
+                    Arg.Is<IEnumerable<object>>(p => ParameterMatchingHelper.DoInvocationParametersMatchSetUpParameters(parameters, p)),
+                    Arg.Any<IModel>())
                 .Returns(callInfo => rawSqlCommand)
                 .AndDoes(callInfo =>
                 {

--- a/src/EntityFrameworkCore.Testing.NSubstitute/Helpers/MockedDbContextFactory.Internal.cs
+++ b/src/EntityFrameworkCore.Testing.NSubstitute/Helpers/MockedDbContextFactory.Internal.cs
@@ -11,12 +11,14 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.Core;
 using NSubstitute.ExceptionExtensions;
 using NSubstitute.Extensions;
+using NSubstitute.ReturnsExtensions;
 
 namespace EntityFrameworkCore.Testing.NSubstitute.Helpers
 {
@@ -101,7 +103,7 @@ namespace EntityFrameworkCore.Testing.NSubstitute.Helpers
 
             //Relational set up
             var rawSqlCommandBuilder = Substitute.For<IRawSqlCommandBuilder>();
-            rawSqlCommandBuilder.Build(Arg.Any<string>(), Arg.Any<IEnumerable<object>>())
+            rawSqlCommandBuilder.Build(Arg.Any<string>(), Arg.Any<IEnumerable<object>>(), Arg.Any<IModel>())
                 .Throws(callInfo =>
                 {
                     Logger.LogDebug("Catch all exception invoked");
@@ -122,6 +124,7 @@ namespace EntityFrameworkCore.Testing.NSubstitute.Helpers
 
             var serviceProvider = Substitute.For<IServiceProvider>();
             serviceProvider.GetService(Arg.Is<Type>(t => t == typeof(IDatabaseFacadeDependencies))).Returns(callInfo => dependencies);
+            serviceProvider.GetService(Arg.Is<Type>(t => t == typeof(IModel))).Returns(callInfo => Substitute.For<IModel>());
 
             ((IInfrastructure<IServiceProvider>) mockedDbContext).Instance.Returns(callInfo => serviceProvider);
 


### PR DESCRIPTION
Added support for running with .NET 9. A pretty simple update, mainly with some versions bumps and documentation updates. 

One breaking change that had to be accounted for to allow building and test success was implementation of the IModel service, which is now required with the new Entity Framework version. Left as an empty mock for now as it doesn't actually need to be used, just needs to be present.